### PR TITLE
fixing typo, that caused the library to fail if a nfc tag with external property

### DIFF
--- a/lib/record.dart
+++ b/lib/record.dart
@@ -80,7 +80,7 @@ enum TypeNameFormat {
   nfcWellKnown,
   media,
   absoluteURI,
-  nfcExternel,
+  nfcExternal,
   unknown,
   unchanged
 }


### PR DESCRIPTION
For my specific application i need to read a nfc tag, that has the applications package identifier within the external ndef record.
When i read the nfc tag using the library i got an error, that the type is not supported. Upon further investigation a simple typo was the cause of this behaviour.